### PR TITLE
Add namespace in gradle to support newer gradle versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "com.yellow.ai.ymchat_flutter"
+
     compileSdkVersion 34
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.yellow.ai.ymchat_flutter">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
This is the error log when we are using this plugin for an app which has newer gradle versions

```
flutter build apk --no-tree-shake-icons --split-per-abi --flavor dev -t lib/main_dev.dart --dart-define-from-file=.env/.env.dev


FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':ymchat_flutter'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 20s
Running Gradle task 'assembleDevRelease'...                        21.0s
Gradle task assembleDevRelease failed with exit code 1
```


This PR contains the changes as per the official docs.
https://developer.android.com/build/configure-app-module#set-namespace

I might raise another PR containing the gradle upgrades.
