### PR TITLE
enhancement/errorEventOnBotLoadFailed

### DIFF
--- a/android/src/main/java/com/yellow/ai/ymchat_flutter/YmchatFlutterPlugin.java
+++ b/android/src/main/java/com/yellow/ai/ymchat_flutter/YmchatFlutterPlugin.java
@@ -29,6 +29,8 @@ public class YmchatFlutterPlugin implements FlutterPlugin, MethodCallHandler {
 
     private EventChannel ymCloseBotEventChannel;
 
+    private EventChannel ymBotLoadFailedEventChannel;
+
     private YmChatService ymChatService;
 
     private Context flutterContext;
@@ -43,8 +45,9 @@ public class YmchatFlutterPlugin implements FlutterPlugin, MethodCallHandler {
 
         ymEventChannel = new EventChannel(flutterPluginBinding.getBinaryMessenger(), "YMChatEvent");
         ymCloseBotEventChannel = new EventChannel(flutterPluginBinding.getBinaryMessenger(), "YMBotCloseEvent");
+        ymBotLoadFailedEventChannel = new EventChannel(flutterPluginBinding.getBinaryMessenger(), "YMBotLoadFailedEvent");
 
-        ymChatService = new YmChatService(ymEventChannel, ymCloseBotEventChannel);
+        ymChatService = new YmChatService(ymEventChannel, ymCloseBotEventChannel, ymBotLoadFailedEventChannel);
     }
 
     @Override

--- a/ios/ymchat_flutter.podspec
+++ b/ios/ymchat_flutter.podspec
@@ -15,7 +15,7 @@ Flutter plugin to integrate with yellow.ai chatbot
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'YMChat', '~> 1.23.0'
+  s.dependency 'YMChat', '~> 1.24.0'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
Added `YMBotLoadFailedEvent` event channel to let user know that bot load failed due to certain outage

```dart
// Listening to bot load failed event
EventChannel _ymBotLoadFailedEventChannel = const EventChannel("YMBotLoadFailedEvent");
_ymBotLoadFailedEventChannel.receiveBroadcastStream().listen((event) {
      // Handle the failure of bot screen loading.
      // Implement appropriate error handling or fallback logic, such as notifying the user or retrying the load process.
      log('YMBotLoadFailedEvent called: Bot failed to load');
});
```