### PR TITLE
Add chatbot Version 3 (V3 widget) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0
+- Added support for chatbot Version 3 (V3 widget). Upgraded native SDKs: Android YMChatbot-Android v3.3.0, iOS YMChat 2.2.0. Call `setVersion(3)` before `startChatbot()` to use it.
+
 ## 2.22.0
 - package updated to support Android target API level 35 for compatibility with latest Android versions.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.yellowmessenger:YMChatbot-Android:v2.22.0'
+    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.0'
 }

--- a/ios/ymchat_flutter.podspec
+++ b/ios/ymchat_flutter.podspec
@@ -15,7 +15,7 @@ Flutter plugin to integrate with yellow.ai chatbot
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'YMChat', '~> 1.24.0'
+  s.dependency 'YMChat', '~> 2.2.0'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ymchat_flutter
 description: Flutter plugin to integrate with yellow.ai chatbot
-version: 2.22.0
+version: 3.0.0
 homepage: "https://github.com/yellowmessenger"
 
 environment:


### PR DESCRIPTION
## What

Adds support for the chatbot **Version 3 (V3 widget)** by upgrading the native SDKs to their first V3-capable releases:

- **Android**: `YMChatbot-Android` `v2.22.0` → `v3.3.0`
- **iOS**: `YMChat` `~> 1.24.0` → `~> 2.2.0`
- Plugin version bumped `2.22.0` → `3.0.0`, `CHANGELOG.md` updated

## Why

The plugin already exposes `YmChat.setVersion(int)`, which passes straight through to the native `YMConfig.version` field with no client-side validation. But `setVersion(3)` had no effect because the pinned native SDKs predated the V3 widget (Android V3 first shipped in v3.0.0; iOS V3 first shipped in the 2.0.0 pod). Bumping both dependencies enables the V3 experience.

## Notes for reviewer

- **No wrapper code changes needed.** All native APIs the plugin calls remain API-compatible in the new SDK versions. Verified directly against the new artifacts:
  - Android v3.3.0 (JitPack): all 11 `YMChat` methods, the `YMConfig(String)` ctor + 15 config fields, `YMTheme`, `YMSpeechConfig`, `YMEventModel`, and `YellowUnreadMessageResponse.getUnreadCount()` are present. `minSdk` stays 21.
  - iOS 2.2.0: every `YMConfig` property, `theme.*`, `speechConfig.*`, `YMChat.shared` method, and `YMChatDelegate` callback used by `SwiftYmchatFlutterPlugin.swift` exists. Deployment target stays iOS 12.0. `pod lib lint` passes.
- **iOS version tracks differ from Android**: iOS V3 = pod `2.x`, Android V3 = `3.x` — both label the feature "V3 Widget Support". `YMChat` 2.x is now published to the CocoaPods trunk, so `~> 2.2.0` resolves.
- **Usage**: call `YmChat.setVersion(3)` before `startChatbot()`.
- Not yet run: an on-device `flutter run` of the example app (no Flutter toolchain in the authoring environment). Recommend a quick manual smoke test on Android + iOS before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)