### PR TITLE
Enable V3 widget in example + add stopVoiceMode API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+- added `stopVoiceMode` method to programmatically stop the bot's voice mode.
+
 ## 3.0.0
 - Added support for chatbot Version 3 (V3 widget). Upgraded native SDKs: Android YMChatbot-Android v3.3.0, iOS YMChat 2.2.0. Call `setVersion(3)` before `startChatbot()` to use it.
 

--- a/android/src/main/java/com/yellow/ai/ymchat_flutter/YmChatService.java
+++ b/android/src/main/java/com/yellow/ai/ymchat_flutter/YmChatService.java
@@ -275,6 +275,10 @@ public class YmChatService {
         ymChat.reloadBot();
     }
 
+    public void stopVoiceMode() {
+        ymChat.stopVoiceMode();
+    }
+
     public void setOpenLinkExternally(boolean shouldOpenLinkExternally) {
        ymChat.config.shouldOpenLinkExternally = shouldOpenLinkExternally;
     }

--- a/android/src/main/java/com/yellow/ai/ymchat_flutter/YmchatFlutterPlugin.java
+++ b/android/src/main/java/com/yellow/ai/ymchat_flutter/YmchatFlutterPlugin.java
@@ -119,6 +119,9 @@ public class YmchatFlutterPlugin implements FlutterPlugin, MethodCallHandler {
             case "reloadBot":
                 reloadBot(result);
                 break;
+            case "stopVoiceMode":
+                stopVoiceMode(result);
+                break;
             case "revalidateToken":
                 revalidateToken(call, result);
                 break;
@@ -252,6 +255,11 @@ public class YmchatFlutterPlugin implements FlutterPlugin, MethodCallHandler {
 
     public void reloadBot(Result result) {
         ymChatService.reloadBot();
+        result.success(true);
+    }
+
+    public void stopVoiceMode(Result result) {
+        ymChatService.stopVoiceMode();
         result.success(true);
     }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,16 +53,13 @@ class _MyAppState extends State<MyApp> {
     YmChat.setEnableSpeech(true);
 
     // using new widget
-    YmChat.setVersion(2);
+    YmChat.setVersion(3);
 
     // Setting statusbar color
     YmChat.setStatusBarColor("#ff0000");
 
     // Setting close button color
     YmChat.setCloseButtonColor("#0400ff");
-
-    // Using lite version
-    YmChat.useLiteVersion(true);
 
     // Listening to bot events
     EventChannel _ymEventChannel = const EventChannel("YMChatEvent");

--- a/ios/Classes/SwiftYmchatFlutterPlugin.swift
+++ b/ios/Classes/SwiftYmchatFlutterPlugin.swift
@@ -99,6 +99,9 @@ public class SwiftYmchatFlutterPlugin: NSObject, FlutterPlugin {
             case "reloadBot":
                 self.reloadBot(result:result);
                 return;
+            case "stopVoiceMode":
+                self.stopVoiceMode(result:result);
+                return;
             case "revalidateToken":
                 revalidateToken(call:call,result:result);
                 break;
@@ -273,6 +276,11 @@ public class SwiftYmchatFlutterPlugin: NSObject, FlutterPlugin {
     }
     private static func closeBot( result: FlutterResult){
         YMChat.shared.closeBot();
+        result(true);
+    }
+
+    private static func stopVoiceMode(result: FlutterResult){
+        YMChat.shared.stopVoiceMode();
         result(true);
     }
 

--- a/lib/ymchat_flutter.dart
+++ b/lib/ymchat_flutter.dart
@@ -182,6 +182,12 @@ class YmChat {
     return isBotReloaded;
   }
 
+  static Future<bool> stopVoiceMode() async {
+    bool isVoiceModeStopped =
+        await _channel.invokeMethod('stopVoiceMode');
+    return isVoiceModeStopped;
+  }
+
   static Future<bool> setOpenLinkExternally(
       bool shouldOpenLinkExternally) async {
     bool isOpenLinkExternallySet = await _channel.invokeMethod(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ymchat_flutter
 description: Flutter plugin to integrate with yellow.ai chatbot
-version: 3.0.0
+version: 3.1.0
 homepage: "https://github.com/yellowmessenger"
 
 environment:


### PR DESCRIPTION
## What

Two related follow-ups on top of the v3 SDK upgrade (#122):

1. **Example app → V3 widget**: switch the demo to `setVersion(3)` and remove `useLiteVersion(true)`. Lite mode suppresses the V3 widget, so it must be off to render it.
2. **New API: `stopVoiceMode()`**: expose the native SDK's `stopVoiceMode()` through the plugin so apps can programmatically stop the bot's voice mode. Version bumped 3.0.0 → 3.1.0.

## Why

- The example still targeted `version(2)`; updating it demonstrates the V3 widget that #122 enabled.
- `stopVoiceMode()` is a public API added in the newer native SDKs (Android v3.3.0, iOS YMChat 2.2.0) that the plugin didn't yet surface.

## Changes

- `example/lib/main.dart` — `setVersion(3)`, drop `useLiteVersion(true)`
- `lib/ymchat_flutter.dart` — `stopVoiceMode()` → `invokeMethod('stopVoiceMode')`
- Android `YmchatFlutterPlugin.java` / `YmChatService.java` — switch case → `ymChat.stopVoiceMode()`
- iOS `SwiftYmchatFlutterPlugin.swift` — dispatch case → `YMChat.shared.stopVoiceMode()`
- `pubspec.yaml` 3.0.0 → 3.1.0, `CHANGELOG.md` entry

## Testing

- Ran the example on the iOS simulator (plugin 3.0.0 + YMChat 2.2.0 pod): the **V3 widget renders correctly** once lite mode is off. Confirmed via A/B that `version=2` loaded the same bot in the old layout and `version=3` (no lite) loads the V3 widget.
- `stopVoiceMode` wired mirroring the existing `closeBot`/`reloadBot` pattern; the native method is confirmed present in both SDKs. `flutter analyze` clean; iOS simulator build succeeds with the new Swift handler.
- Not run: Android emulator pass, and a runtime exercise of `stopVoiceMode` (needs an active voice session). Recommend a quick manual check on Android before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)