### PR TITLE
Bump native SDK deps for WebView security fix (v3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+- Security fix: upgraded native SDKs to pick up a WebView URL-handling fix — Android YMChatbot-Android v3.3.1, iOS YMChat 2.2.1. No Dart API changes.
+
 ## 3.1.0
 - added `stopVoiceMode` method to programmatically stop the bot's voice mode.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.0'
+    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.1'
 }

--- a/ios/ymchat_flutter.podspec
+++ b/ios/ymchat_flutter.podspec
@@ -15,7 +15,7 @@ Flutter plugin to integrate with yellow.ai chatbot
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'YMChat', '~> 2.2.0'
+  s.dependency 'YMChat', '~> 2.2.1'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ymchat_flutter
 description: Flutter plugin to integrate with yellow.ai chatbot
-version: 3.1.0
+version: 3.1.1
 homepage: "https://github.com/yellowmessenger"
 
 environment:


### PR DESCRIPTION
## Summary
- Bumps the Android dependency to `com.github.yellowmessenger:YMChatbot-Android:v3.3.1` in `android/build.gradle`.
- Bumps the iOS dependency to `YMChat ~> 2.2.1` in `ios/ymchat_flutter.podspec`.
- Bumps the plugin version to `3.1.1` in `pubspec.yaml` and adds a changelog entry.
- No Dart API changes — this is purely a native SDK dependency bump.

## Why
Both native SDKs shipped a WebView URL-handling security fix (tracked as ISS-15626, originating from a validated bug bounty report on the Android SDK): a JS-bridge method that loaded arbitrary URLs with no scheme check, and a WebView navigation policy that could load links in-WebView instead of externally / accept non-http(s) navigations. Fixed in:
- Android: yellowmessenger/YMChatbot-Android#129
- iOS: yellowmessenger/YMChatbot-iOS#84

## ⚠️ Blocked on native releases — do not merge yet
Neither native version referenced here is actually published yet:
- `v3.3.1` is not yet tagged on `YMChatbot-Android` (PR #129 is still open) — JitPack cannot resolve it until the tag exists.
- `2.2.1` has not been pushed to CocoaPods trunk for `YMChat` (PR #84 is still open) — `pod install` cannot resolve it until it's published.

This PR should stay open until both of those land, otherwise `flutter pub get` / `pod install` against this branch will fail to resolve dependencies.

## Test plan
- [ ] Re-verify `flutter pub get` (Android) and `pod install` (iOS, in `example/ios`) resolve cleanly once the native versions are published.
- [ ] Smoke-test the example app on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)