### PR TITLE
Bump Android SDK for popup WebView security fix (v3.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+- Security fix: upgraded native Android SDK to YMChatbot-Android v3.3.2, closing a residual WebView popup (`window.open()`) URL-scheme gap left over from the v3.3.1 fix. No Dart API changes.
+
 ## 3.1.1
 - Security fix: upgraded native SDKs to pick up a WebView URL-handling fix — Android YMChatbot-Android v3.3.1, iOS YMChat 2.2.1. No Dart API changes.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.1'
+    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.2'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ymchat_flutter
 description: Flutter plugin to integrate with yellow.ai chatbot
-version: 3.1.1
+version: 3.1.2
 homepage: "https://github.com/yellowmessenger"
 
 environment:


### PR DESCRIPTION
## Summary
- Bumps the Android dependency to `com.github.yellowmessenger:YMChatbot-Android:v3.3.2` in `android/build.gradle` (was `v3.3.1`).
- Bumps the plugin version to `3.1.2` and adds a changelog entry.
- No Dart API changes. iOS dependency is unchanged (see below).

## Why
`v3.3.2` closes a residual gap from the original `v3.3.1` fix (ISS-15626): the popup WebView opened via `window.open()`/`target=_blank` (`onCreateWindow`) is a separate WebView instance that didn't inherit the main WebView's http(s)-only scheme allowlist or `allowFileAccess = false` setting, so `javascript:`/`file:` URLs could still load there. Fixed in yellowmessenger/YMChatbot-Android#130, released as `v3.3.2`.

iOS is not affected by this follow-up — its `window.open()` handler (`createWebViewWith` in `WKUIDelegate`) never creates a real `WKWebView` (always returns `nil`), so there's no equivalent popup-rendering surface there. No iOS podspec change needed.

## Test plan
- [ ] `flutter pub get` resolves the new Android dependency.
- [ ] Smoke-test a chat popup link on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)