### PR TITLE
Bump native SDKs for Voice Mode screen-wake fix (3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+- Upgraded native SDKs to pick up automatic screen-awake handling during Voice Mode — Android YMChatbot-Android v3.4.0, iOS YMChat 2.3.0. The screen now stays on for the duration of an active voice conversation and returns to normal on call end; entirely internal to the native SDKs, no Dart API changes.
+
 ## 3.1.2
 - Security fix: upgraded native Android SDK to YMChatbot-Android v3.3.2, closing a residual WebView popup (`window.open()`) URL-scheme gap left over from the v3.3.1 fix. No Dart API changes.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.3.2'
+    implementation 'com.github.yellowmessenger:YMChatbot-Android:v3.4.0'
 }

--- a/ios/ymchat_flutter.podspec
+++ b/ios/ymchat_flutter.podspec
@@ -15,7 +15,7 @@ Flutter plugin to integrate with yellow.ai chatbot
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'YMChat', '~> 2.2.1'
+  s.dependency 'YMChat', '~> 2.3.0'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ymchat_flutter
 description: Flutter plugin to integrate with yellow.ai chatbot
-version: 3.1.2
+version: 3.2.0
 homepage: "https://github.com/yellowmessenger"
 
 environment:


### PR DESCRIPTION
## Summary
- Bumps the pinned native SDK deps: Android `YMChatbot-Android` v3.3.2 → v3.4.0, iOS `YMChat` ~> 2.2.1 → ~> 2.3.0.
- Both releases add automatic screen-awake handling during Voice Mode (screen stays on for the duration of an active voice call, restores on end) — entirely internal to the native SDKs, no Dart API changes here.

## Test plan
- [ ] `pod install` in `example/ios` and confirm `YMChat 2.3.0` resolves
- [ ] Gradle sync in `example/android` and confirm `YMChatbot-Android:v3.4.0` resolves
- [ ] Manual: start Voice Mode via the example app, confirm the screen doesn't lock during the call